### PR TITLE
Use GitHub release to build the blog-nginx image

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,12 +11,12 @@ cd blog-deploy
 
 ### Build `blognginx` image
 Prepare `frontend` static files
-- Build the static files from [blog-frontend repo](https://github.com/bradleyzhou/blog-frontend) (e.g. run `npm run build`)
-* Put these files under `nging/frontend` directory (e.g. rename and move `dist` directory)
+- Build the static files from [blog-frontend repo](https://github.com/bradleyzhou/blog-frontend) (e.g. run `npm run build`) and create a `tar.gz` bundle. Normally this should done automatically via Travis CI.
+- Get the release number from the ['releases' page](https://github.com/bradleyzhou/blog-frontend/releases) , e.g. 'v1.0.0'
 
 This image exposes ports `80` and `443`
 ```
-docker build -t blognginx nginx
+docker build --build-arg blog_frontend_release=<type_in_the_release_number> -t blognginx nginx
 ```
 
 ### Build `blogapi` image

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -2,8 +2,13 @@ FROM nginx
 
 EXPOSE 80 443
 
+ARG blog_frontend_release
+ARG release_url=https://github.com/bradleyzhou/blog-frontend/releases/download/${blog_frontend_release}/blog-frontend-${blog_frontend_release}.tar.gz
+
 ADD ./nginx.conf /etc/nginx/
-ADD ./frontend /var/www/blog
+ADD ${release_url} dist.tar.gz
+RUN mkdir -p /var/www && tar xvzf dist.tar.gz -C /var/www/
+RUN mv /var/www/dist /var/www/blog
 
 STOPSIGNAL SIGQUIT
 


### PR DESCRIPTION
The `blog-frontend` just got updated to auto-build release gzipped tarballs via Travis. This is a good time to update the Docker image building process here.